### PR TITLE
runCommanderT-less-points

### DIFF
--- a/commandert.cabal
+++ b/commandert.cabal
@@ -4,7 +4,7 @@ name:                commandert
 version:             0.1.0.0
 synopsis:            A monad for commanders
 description:         A monad for commanders.
-homepage:            https://github.com/SamuelSchlesinger/commandert
+homepage:            https://github.com/SamuelSchlesinger/commander
 bug-reports:         https://github.com/SamuelSchlesinger/commander/issues
 license:             MIT
 license-file:        LICENSE

--- a/src/Control/Monad/Commander.hs
+++ b/src/Control/Monad/Commander.hs
@@ -47,9 +47,7 @@ runCommanderT :: Monad m
               => CommanderT state m a 
               -> state 
               -> m (Maybe a)
-runCommanderT (Action action) state = do
-  (action', state') <- action state
-  runCommanderT action' state'
+runCommanderT (Action action) state = action state >>= uncurry runCommanderT
 runCommanderT Defeat _ = return Nothing
 runCommanderT (Victory a) _ = return (Just a)
 


### PR DESCRIPTION
runCommanderT was hard to read and had points that could be conflated

Now just has a bind instead of 2 line do
